### PR TITLE
feat: add exclusion label for node lifecycle management

### DIFF
--- a/controllers/nodelifecycle/node_lifecycle_controller.go
+++ b/controllers/nodelifecycle/node_lifecycle_controller.go
@@ -50,6 +50,9 @@ const (
 	instanceExistsOp   = "instance_exists"
 	instanceShutdownOp = "instance_shutdown"
 	instanceMetadataOp = "instance_metadata"
+
+	// LabelNodeLifecycleExclude is the label used to exclude a node from lifecycle management
+	LabelNodeLifecycleExclude = "node.kubernetes.io/exclude-from-lifecycle-management"
 )
 
 var ShutdownTaint = &v1.Taint{
@@ -154,6 +157,12 @@ func (c *CloudNodeLifecycleController) MonitorNodes(ctx context.Context) {
 
 	processNode := func(piece int) {
 		node := nodes[piece].DeepCopy()
+		// Skip nodes with the lifecycle exclusion label
+		if _, excluded := node.Labels[LabelNodeLifecycleExclude]; excluded {
+			klog.V(4).Infof("Skipping node %s due to exclusion label %s", node.Name, LabelNodeLifecycleExclude)
+			return
+		}
+
 		// Default NodeReady status to v1.ConditionUnknown
 		status := v1.ConditionUnknown
 		if _, c := nodeutil.GetNodeCondition(&node.Status, v1.NodeReady); c != nil {

--- a/controllers/nodelifecycle/node_lifecycle_controller_test.go
+++ b/controllers/nodelifecycle/node_lifecycle_controller_test.go
@@ -509,6 +509,51 @@ func Test_NodesDeleted(t *testing.T) {
 				ExistsByProviderID: false,
 			},
 		},
+		{
+			name: "node is not ready and does not exist, but has exclusion label",
+			existingNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					Labels: map[string]string{
+						LabelNodeLifecycleExclude: "true",
+					},
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionFalse,
+							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			expectedNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					Labels: map[string]string{
+						LabelNodeLifecycleExclude: "true",
+					},
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionFalse,
+							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			expectedDeleted: false,
+			fakeCloud: &fakecloud.Cloud{
+				ExistsByProviderID: false,
+			},
+		},
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
Add support for excluding nodes from CloudNodeLifecycleController management via the node.kubernetes.io/exclude-from-lifecycle-management label. Nodes with this label will not be deleted even when their corresponding cloud instances do not exist.